### PR TITLE
Allow null values for log-text

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2956,7 +2956,7 @@ def post_tasks(parser, xml_parent, data):
                 matches_xml,
                 'hudson.plugins.postbuildtask.LogProperties')
             XML.SubElement(lt_xml, 'logText').text = str(
-                match.get('log-text', ''))
+                match.get('log-text', False) or '')
             XML.SubElement(lt_xml, 'operator').text = str(
                 match.get('operator', 'AND')).upper()
         XML.SubElement(task_xml, 'EscalateStatus').text = str(

--- a/tests/publishers/fixtures/post-tasks002.xml
+++ b/tests/publishers/fixtures/post-tasks002.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <publishers>
+    <hudson.plugins.postbuildtask.PostbuildTask>
+      <tasks>
+        <hudson.plugins.postbuildtask.TaskProperties>
+          <logTexts>
+            <hudson.plugins.postbuildtask.LogProperties>
+              <logText/>
+              <operator>AND</operator>
+            </hudson.plugins.postbuildtask.LogProperties>
+          </logTexts>
+          <EscalateStatus>true</EscalateStatus>
+          <RunIfJobSuccessful>true</RunIfJobSuccessful>
+          <script>echo &quot;Here goes the task script&quot;
+</script>
+        </hudson.plugins.postbuildtask.TaskProperties>
+      </tasks>
+    </hudson.plugins.postbuildtask.PostbuildTask>
+  </publishers>
+</project>

--- a/tests/publishers/fixtures/post-tasks002.yaml
+++ b/tests/publishers/fixtures/post-tasks002.yaml
@@ -1,0 +1,9 @@
+publishers:
+  - post-tasks:
+    - matches:
+      - log-text: null
+        operator: AND
+      escalate-status: true
+      run-if-job-successful: true
+      script: |
+        echo "Here goes the task script"


### PR DESCRIPTION
The log-text parameter is required according to the documentation,
but it's perfectly valid for it to be an empty string or null.

If the value is null in the yaml, the Python data structure
contains None. The code was converting this directly to a string,
resulting in 'None' in the xml output.

This change makes sure that an empty string is used instead,
resulting in a correct empty element in the xml.

Change-Id: Ided872f5528bae93347f96bd729b5ce37f8e16fb
