### PR TITLE
Fix missing slack properties

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -674,6 +674,8 @@ def slack(parser, xml_parent, data):
     :arg str custom-message: Custom message to be included. (default: '')
     :arg str room: A comma seperated list of rooms / channels to send
         the notifications to. (default: '')
+    :arg str team-domain: The slack domain. (default: '')
+    :arg str token: The slack api token. (default: '')
 
     Example:
 
@@ -698,6 +700,8 @@ def slack(parser, xml_parent, data):
         ('include-custom-message', 'includeCustomMessage', False),
         ('custom-message', 'customMessage', ''),
         ('room', 'room', ''),
+        ('team-domain', 'teamDomain', ''),
+        ('token', 'token', ''),
     )
 
     slack = XML.SubElement(

--- a/tests/properties/fixtures/slack001.xml
+++ b/tests/properties/fixtures/slack001.xml
@@ -13,6 +13,8 @@
       <includeCustomMessage>false</includeCustomMessage>
       <customMessage/>
       <room>dummy, dummy2</room>
+      <teamDomain/>
+      <token/>
     </jenkins.plugins.slack.SlackNotifier_-SlackJobProperty>
   </properties>
 </project>

--- a/tests/properties/fixtures/slack002.xml
+++ b/tests/properties/fixtures/slack002.xml
@@ -12,7 +12,9 @@
       <includeTestSummary>false</includeTestSummary>
       <includeCustomMessage>true</includeCustomMessage>
       <customMessage>Custom foo message</customMessage>
-      <room/>
+      <room>#my-room</room>
+      <teamDomain>my-slack-domain</teamDomain>
+      <token>my-slack-token</token>
     </jenkins.plugins.slack.SlackNotifier_-SlackJobProperty>
   </properties>
 </project>

--- a/tests/properties/fixtures/slack002.yaml
+++ b/tests/properties/fixtures/slack002.yaml
@@ -5,3 +5,6 @@ properties:
         notify-aborted: true
         include-custom-message: true
         custom-message: 'Custom foo message'
+        team-domain: my-slack-domain
+        token: my-slack-token
+        room: '#my-room'


### PR DESCRIPTION
To generate complete XML that can properly override global
slack settings, the details need to be duplicated in the
properties, too. Without this, the slack plugin can end up
with empty elements overriding the global settings, resulting
in a global config that works, but individual jobs that do not.

Change-Id: Ibb37a03ce0e4ae506205fbb57193a467d055212b
