### PR TITLE
Use xml_jobs not jobs

### DIFF
--- a/jenkins_jobs/cli/subcommand/update.py
+++ b/jenkins_jobs/cli/subcommand/update.py
@@ -96,7 +96,7 @@ class UpdateSubCommand(base.BaseSubCommand):
             n_workers=options.n_workers)
         logger.info("Number of jobs updated: %d", num_updated_jobs)
 
-        keep_jobs = [job.name for job in jobs]
+        keep_jobs = [job.name for job in xml_jobs]
         if options.delete_old:
             n = builder.delete_old_managed(keep=keep_jobs)
             logger.info("Number of jobs deleted: %d", n)


### PR DESCRIPTION
Fixes a regression where using --delete-old will delete jobs that are
not updated for example in the case of caching and jenkins-jobs
determines a job does not need to be updated.

jobs returns a list of jobs that were updated via jenkins-jobs while
xml_jobs returns a list of all jobs generated jobs regardless of if they
were updated or not.

Change-Id: I8f9d0b609d1a7cc0a526d479b4f0a2448c25aba3
